### PR TITLE
Fix x-axis label alignment in dotmap for rotated labels

### DIFF
--- a/R/plot_dotmap.R
+++ b/R/plot_dotmap.R
@@ -307,9 +307,12 @@ plot_dotmap <- function(
         ggplot2::theme(
             axis.text.x = ggplot2::element_text(
                 angle = xlab_angle,
-                vjust = 0.5,
-                hjust = 0.5, # center-align (also when rotated), for top axis
-                margin = ggplot2::margin(t = -6, b = 0)
+                vjust = ifelse(xlab_angle == 0, 0.5, 1),
+                hjust = ifelse(xlab_angle == 0, 0.5, 0), # center when horizontal, left-align when rotated (top axis)
+                margin = ggplot2::margin(
+                    t = ifelse(xlab_angle == 0, 0, -6),
+                    b = 0
+                )
             )
         )
 

--- a/inst/test.R
+++ b/inst/test.R
@@ -1,146 +1,33 @@
 devtools::load_all()
 
-data(ex_data_heatmap)
-
-ht_cols_small <- circlize::colorRamp2(
-    c(min(1:16), mean(1:16), max(1:16)),
-    c("#145afc", "white", "#ee4445")
+set.seed(42)
+genes <- paste0("gene", 1:6)
+df <- expand.grid(
+    col = c("Aaaaaaaaaaaaaaaa", "Bbbbbbbbbbbbb", "Cccccccccccccc"),
+    row = genes,
+    stringsAsFactors = FALSE
 )
-
-ann_cols_small <- list(
-    group = c(G1 = "#1b9e77", G2 = "#d95f02"),
-    direction = c(up = "#e41a1c", down = "#4daf4a"),
-    is_immune_gene = c(yes = "#fb8072", no = "#d9d9d9"),
-    sample_type = c(input = "#8dd3c7", IP = "#80b1d3"),
-    condition = c(healthy = "#b3de69", EAE = "#fccde5")
+df$effect <- rnorm(nrow(df), mean = 0, sd = 1.2) # realistic effect sizes
+df$mlog10_p <- runif(nrow(df), min = 0, max = 3) # -log10(p) between 0 and 3
+df$p <- 10^(-df$mlog10_p)
+df$row <- factor(df$row, levels = rev(genes))
+plot_dotmap(
+    df,
+    x = "col",
+    y = "row",
+    effect = "effect",
+    p = "p",
+    mlog10_transform_pvalue = TRUE
 )
-
-# make a categorical heatmap
-cat_data <- ex_data_heatmap
-cat_data$expression <- as.character(cut(
-    cat_data$expression,
-    breaks = c(-Inf, 3, 6, Inf),
-    labels = c("low", "medium", "high")
-))
-
-
-# default colors
-plot_heatmap(
-    df = cat_data,
-    row_var = external_gene_name,
-    col_var = sample,
-    value_var = expression,
-    row_covariates = c("is_immune_gene", "direction"),
-    col_covariates = c("sample_type", "condition", "group"),
-    row_split_var = "direction", # up vs down (2 slices)
-    col_split_var = "group", # G1 vs G2 (2 slices)
-    scale_rows = FALSE,
-    cluster_rows = TRUE,
-    cluster_columns = TRUE,
-    return_details = TRUE,
-    row_names_side = "left"
-)
-
-# custom colors
-heat_cat_colors <- c(
-    low = "#313695",
-    medium = "#f7f7f7",
-    high = "#a50026"
-)
-
-plot_heatmap(
-    df = cat_data,
-    row_var = external_gene_name,
-    col_var = sample,
-    heatmap_colors = heat_cat_colors,
-    value_var = expression,
-    row_covariates = c("is_immune_gene", "direction"),
-    col_covariates = c("sample_type", "condition", "group"),
-    row_split_var = "direction", # up vs down (2 slices)
-    col_split_var = "group", # G1 vs G2 (2 slices)
-    scale_rows = FALSE,
-    cluster_rows = TRUE,
-    cluster_columns = TRUE,
-    return_details = TRUE,
-    row_names_side = "left"
-)
-
-######### heatmap with continuous values
-
-# default colors
-plot_heatmap(
-    df = ex_data_heatmap,
-    row_var = external_gene_name,
-    col_var = sample,
-    value_var = expression,
-    row_covariates = c("is_immune_gene", "direction"),
-    col_covariates = c("sample_type", "condition", "group"),
-    row_split_var = "direction", # up vs down (2 slices)
-    col_split_var = "group", # G1 vs G2 (2 slices)
-    scale_rows = FALSE,
-    cluster_rows = TRUE,
-    cluster_columns = TRUE,
-    return_details = TRUE,
-    row_names_side = "left"
-)
-# custom colors
-plot_heatmap(
-    df = ex_data_heatmap,
-    row_var = external_gene_name,
-    col_var = sample,
-    value_var = expression,
-    row_covariates = c("is_immune_gene", "direction"),
-    col_covariates = c("sample_type", "condition", "group"),
-    row_split_var = "direction",
-    col_split_var = "group",
-    scale_rows = FALSE,
-    cluster_rows = FALSE,
-    cluster_columns = FALSE,
-    heatmap_colors = ht_cols_small,
-    anno_colors = ann_cols_small,
-    return_details = TRUE
-)
-### Continuous row and column covariates via colorRamp2 functions
-rng_log2fc <- range(ex_data_heatmap$log2fc, na.rm = TRUE)
-col_fun_log2fc <- circlize::colorRamp2(
-    c(rng_log2fc[1], 0, rng_log2fc[2]),
-    c("#762a83", "white", "#e66101")
-)
-
-rng_qc <- range(ex_data_heatmap$qc_score, na.rm = TRUE)
-col_fun_qc <- circlize::colorRamp2(
-    c(rng_qc[1], mean(rng_qc), rng_qc[2]),
-    c("#ffffcc", "#41b6c4", "#0c2c84")
-)
-
-expr_rng <- range(ex_data_heatmap$expression, na.rm = TRUE)
-expr_cols <- circlize::colorRamp2(
-    c(expr_rng[1], mean(expr_rng), expr_rng[2]),
-    c("#313695", "#f7f7f7", "#a50026")
-)
-
-plot_heatmap(
-    df = ex_data_heatmap,
-    row_var = external_gene_name,
-    col_var = sample,
-    value_var = expression,
-    row_covariates = c("log2fc", "is_immune_gene", "direction"),
-    col_covariates = c("qc_score", "condition", "sample_type"),
-    col_split_var = "group",
-    row_split_var = "direction",
-    heatmap_colors = expr_cols,
-    anno_colors = list(
-        log2fc = col_fun_log2fc,
-        qc_score = col_fun_qc,
-        is_immune_gene = c(yes = "#e7298a", no = "#a6761d"),
-        direction = c(up = "#1f78b4", down = "#e31a1c"),
-        condition = c(healthy = "#1b9e77", EAE = "#d95f02"),
-        sample_type = c(input = "#7570b3", IP = "#66a61e")
-    ),
-    scale_rows = FALSE,
-    cluster_rows = TRUE,
-    cluster_columns = TRUE,
-    show_row_names = TRUE,
-    row_names_side = "left",
-    heatmap_legend_title = "Expression"
+# Add Fisher's combination pvalue barplot on the right which combines p-values across columns for each row category
+plot_dotmap(
+    df,
+    x = "col",
+    y = "row",
+    effect = "effect",
+    p = "p",
+    mlog10_transform_pvalue = TRUE,
+    add_combined_pvalue_barplot = TRUE,
+    combine_pvalue_method = "CMC",
+    xlab_angle = 45
 )


### PR DESCRIPTION
Adjust vjust, hjust, and top margin of x-axis text dynamically based on xlab_angle: center-align when horizontal (0°), left-align with proper spacing when rotated. Simplify test script to focus on dotmap examples.