### PR TITLE
Refactor plot_confidence_intervals: replace `style` param with indepe…

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,11 +6,24 @@
 
 ## Changed
 
-...
+* `plot_confidence_intervals`: refactor — replace the monolithic `style`
+  parameter with independent arguments for visual encoding and layout:
+  `color_col`, `color_values`, `shape_col`, and `point_shapes` (for
+  shape-based grouping), plus separator and reference-line controls
+  (`show_separators`, `sep_linetype`, `sep_linewidth`, `sep_color`,
+  `vline_xintercept`, `vline_linetype`, `vline_color`) and `dodge_width`.
+  This makes styling explicit and composable and simplifies legend
+  handling.
+
+* `plot_confidence_intervals`: ensure `shape_col` is coerced to a factor
+  with a stable, sorted level ordering; validate `point_shapes` length
+  against the number of shape levels and provide clearer legend
+  overrides when `color_col` and/or `shape_col` are used.
 
 ## Fixed
 
 ...
+
 
 # statplot 0.5.0 - 2026-04-10
 

--- a/R/plot_confidence_intervals.R
+++ b/R/plot_confidence_intervals.R
@@ -36,8 +36,10 @@
 #'   `c(g1 = "#FF0000", g2 = "#0000FF")`). If `NULL` (default), ggplot2's
 #'   default color scale is used. Ignored if `color_col` is `NULL`.
 #' @param shape_col Optional string name of a column to use for point shapes.
-#'   When `NULL` (default), no shape encoding is applied. Must be a factor or
-#'   character column. Can be used independently or in combination with `color_col`.
+#'   When `NULL` (default), no shape encoding is applied. Can be a factor or
+#'   character column; character columns are coerced to factor with sorted level
+#'   ordering for stable shape assignment. Can be used independently or in
+#'   combination with `color_col`.
 #' @param point_shapes Integer vector of point shapes to use when
 #'   `shape_col` is specified. Must have at least as many elements as there are
 #'   levels in `shape_col`. Defaults to `c(21, 24, 22, 25, 23)` (up to 5
@@ -271,9 +273,20 @@ plot_confidence_intervals <- function(
             length(point_shapes) >= 1
     )
 
+    d <- data
+
+    # ---- coerce shape_col to factor with stable level ordering ----
+    if (!is.null(shape_col)) {
+        if (!is.factor(d[[shape_col]])) {
+            # Convert character to factor with sorted levels for stability
+            unique_vals <- unique(as.character(d[[shape_col]]))
+            d[[shape_col]] <- factor(d[[shape_col]], levels = sort(unique_vals))
+        }
+    }
+
     # Validate point_shapes length against number of shape_col levels
     if (!is.null(shape_col)) {
-        n_shapes_check <- nlevels(data[[shape_col]])
+        n_shapes_check <- nlevels(d[[shape_col]])
         if (length(point_shapes) < n_shapes_check) {
             stop(
                 "point_shapes has ",
@@ -290,8 +303,6 @@ plot_confidence_intervals <- function(
             )
         }
     }
-
-    d <- data
 
     # ---- y positions from factor levels ----
     # label levels run top-to-bottom: first level -> highest y value

--- a/R/plot_confidence_intervals.R
+++ b/R/plot_confidence_intervals.R
@@ -18,13 +18,11 @@
 #'   **factor**; factor levels control the top-to-bottom row ordering (first
 #'   level appears at the top).
 #' @param dodge_width Numeric. Total vertical spread across groups. Default `0.3`.
-#' @param style String. Controls group encoding when `group_col` is supplied.
-#'   `"color"` (default) uses different colors per group and draws horizontal
-#'   separator lines between rows. `"shape"` uses the same color per
-#'   `id` row and different point shapes per group.
-#' @param sep_linetype Line type for row separator lines when `style = "color"`. Default `"solid"`.
-#' @param sep_linewidth Line width for row separator lines when `style = "color"`. Default `0.4`.
-#' @param sep_color Color for row separator lines when `style = "color"`. Default `"black"`.
+#' @param show_separators Logical. Whether to draw horizontal separator lines
+#'   between rows when `group_col` is supplied. Default `TRUE`.
+#' @param sep_linetype Line type for row separator lines. Default `"solid"`.
+#' @param sep_linewidth Line width for row separator lines. Default `0.4`.
+#' @param sep_color Color for row separator lines. Default `"black"`.
 #' @param vline_xintercept Numeric. Position of the vertical reference line. Default `0`.
 #' @param vline_linetype Line type for the vertical reference line. Default `"dashed"`.
 #' @param vline_color Color for the vertical reference line. Default `"black"`.
@@ -37,9 +35,12 @@
 #'   values should be valid R color names or hex codes (e.g.,
 #'   `c(g1 = "#FF0000", g2 = "#0000FF")`). If `NULL` (default), ggplot2's
 #'   default color scale is used. Ignored if `color_col` is `NULL`.
+#' @param shape_col Optional string name of a column to use for point shapes.
+#'   When `NULL` (default), no shape encoding is applied. Must be a factor or
+#'   character column. Can be used independently or in combination with `color_col`.
 #' @param point_shapes Integer vector of point shapes to use when
-#'   `style = "shape"`. Must have at least as many elements as there are
-#'   levels in `group_col`. Defaults to `c(21, 24, 22, 25, 23)` (up to 5
+#'   `shape_col` is specified. Must have at least as many elements as there are
+#'   levels in `shape_col`. Defaults to `c(21, 24, 22, 25, 23)` (up to 5
 #'   groups). See [graphics::points()] for shape codes.
 #' @param pvalue_col Optional string name of a column in `data` containing
 #'   p-values (one per row). When supplied, a [plot_pvalue_barplot()] is
@@ -102,7 +103,8 @@
 #'   ci_high = "conf.high",
 #'   id = "cell_line",
 #'   group_col = "group",
-#'   style = "shape"
+#'   shape_col = "group",
+#'   show_separators = FALSE
 #' )
 #'
 #' # With grouping: color by group with custom colors
@@ -117,7 +119,7 @@
 #'   color_values = c(g1 = "#E69F00", g2 = "#56B4E9")
 #' )
 #'
-#' # Color by label instead of group
+#' # Color by label, shapes by group
 #' plot_confidence_intervals(
 #'   df,
 #'   effect_size = "est",
@@ -125,7 +127,7 @@
 #'   ci_high = "conf.high",
 #'   id = "cell_line",
 #'   group_col = "group",
-#'   style = "shape",
+#'   shape_col = "group",
 #'   color_col = "cell_line"
 #' )
 #'
@@ -163,7 +165,8 @@ plot_confidence_intervals <- function(
     dodge_width = 0.3,
     color_col = NULL,
     color_values = NULL,
-    style = c("color", "shape"),
+    show_separators = TRUE,
+    shape_col = NULL,
     sep_linetype = "solid",
     sep_linewidth = 0.4,
     sep_color = "black",
@@ -183,7 +186,6 @@ plot_confidence_intervals <- function(
     pvalue_plot_margin = c(5.5, 12, 5.5, 0),
     ...
 ) {
-    style <- match.arg(style)
     combine_pvalue_method <- match.arg(combine_pvalue_method)
 
     # ---- input validation ----
@@ -210,6 +212,12 @@ plot_confidence_intervals <- function(
             color_values
         ) ||
             (is.character(color_values) && !is.null(names(color_values))),
+        "show_separators must be logical" = is.logical(show_separators) &&
+            length(show_separators) == 1,
+        "shape_col must be NULL or a single string" = is.null(shape_col) ||
+            (is.character(shape_col) && length(shape_col) == 1),
+        "shape_col must be a column in data" = is.null(shape_col) ||
+            shape_col %in% names(data),
         "group_col must be NULL or a single string" = is.null(group_col) ||
             (is.character(group_col) && length(group_col) == 1),
         "group_col must be a column in data" = is.null(group_col) ||
@@ -263,21 +271,21 @@ plot_confidence_intervals <- function(
             length(point_shapes) >= 1
     )
 
-    # Validate point_shapes length against number of groups when style = "shape"
-    if (!is.null(group_col) && style == "shape") {
-        n_groups_check <- nlevels(data[[group_col]])
-        if (length(point_shapes) < n_groups_check) {
+    # Validate point_shapes length against number of shape_col levels
+    if (!is.null(shape_col)) {
+        n_shapes_check <- nlevels(data[[shape_col]])
+        if (length(point_shapes) < n_shapes_check) {
             stop(
                 "point_shapes has ",
                 length(point_shapes),
                 " element(s) but ",
-                "group_col '",
-                group_col,
+                "shape_col '",
+                shape_col,
                 "' has ",
-                n_groups_check,
+                n_shapes_check,
                 " levels. ",
                 "Provide a point_shapes vector with at least ",
-                n_groups_check,
+                n_shapes_check,
                 " elements."
             )
         }
@@ -316,8 +324,8 @@ plot_confidence_intervals <- function(
             color = vline_color
         )
 
-    # ---- row separator lines (style = "color" only) ----
-    if (!is.null(group_col) && style == "color" && n_units > 1) {
+    # ---- row separator lines ----
+    if (!is.null(group_col) && show_separators && n_units > 1) {
         separators <- seq_len(n_units - 1) + 0.5
         p <- p +
             ggplot2::geom_hline(
@@ -361,8 +369,8 @@ plot_confidence_intervals <- function(
     }
 
     # ---- points ----
-    if (!is.null(group_col) && style == "shape") {
-        # shape style: use point_shapes for groups, color for color_col
+    if (!is.null(shape_col)) {
+        # Use shapes for shape_col, optionally with colors
         if (!is.null(color_col)) {
             p <- p +
                 ggplot2::geom_point(
@@ -370,14 +378,14 @@ plot_confidence_intervals <- function(
                         y = y_pos,
                         color = .data[[color_col]],
                         fill = .data[[color_col]],
-                        shape = .data[[group_col]]
+                        shape = .data[[shape_col]]
                     ),
                     size = 4,
                     stroke = 0.4,
                     show.legend = TRUE
                 ) +
                 ggplot2::scale_shape_manual(
-                    values = point_shapes[seq_len(nlevels(d[[group_col]]))]
+                    values = point_shapes[seq_len(nlevels(d[[shape_col]]))]
                 )
             if (!is.null(color_values)) {
                 p <- p +
@@ -389,7 +397,7 @@ plot_confidence_intervals <- function(
                 ggplot2::geom_point(
                     ggplot2::aes(
                         y = y_pos,
-                        shape = .data[[group_col]]
+                        shape = .data[[shape_col]]
                     ),
                     size = 4,
                     stroke = 0.4,
@@ -398,11 +406,11 @@ plot_confidence_intervals <- function(
                     show.legend = TRUE
                 ) +
                 ggplot2::scale_shape_manual(
-                    values = point_shapes[seq_len(nlevels(d[[group_col]]))]
+                    values = point_shapes[seq_len(nlevels(d[[shape_col]]))]
                 )
         }
     } else if (!is.null(color_col)) {
-        # color specified: use it for points
+        # Color specified: use it for points
         p <- p +
             ggplot2::geom_point(
                 ggplot2::aes(
@@ -420,7 +428,7 @@ plot_confidence_intervals <- function(
                 ggplot2::scale_fill_manual(values = color_values)
         }
     } else {
-        # no grouping or color: plain points
+        # No shape or color: plain points
         p <- p +
             ggplot2::geom_point(
                 ggplot2::aes(y = y_pos),
@@ -443,8 +451,8 @@ plot_confidence_intervals <- function(
         ggplot2::theme_bw() +
         ggplot2::theme(axis.text.y = ggplot2::element_text(face = "bold"))
 
-    # Add shape legend overrides when using shape style
-    if (!is.null(group_col) && style == "shape") {
+    # Add shape legend overrides when using shape_col
+    if (!is.null(shape_col)) {
         # Only override color to black if no color_col specified
         override_aes <- list(linetype = 0, linewidth = 0)
         if (is.null(color_col)) {

--- a/R/plot_pvalue_barplot.R
+++ b/R/plot_pvalue_barplot.R
@@ -82,7 +82,7 @@ plot_pvalue_barplot <- function(
     vline_color = "red",
     vline_legend = TRUE,
     show_y_labels = FALSE, # whether to show y-axis labels (default FALSE)
-    mlog10_transform_pvalue = FALSE, # when TRUE compute -log10(p) for plotting/order
+    mlog10_transform_pvalue = TRUE, # when TRUE compute -log10(p) for plotting/order
     also_show_qvalue = TRUE, # when TRUE compute q-values (FDR) and draw p-values (grey, behind) plus q-values (black, on top) per row
     custom_qvalues = NULL, # column name in `data` containing user-supplied q-values
     color_qvalue = 'grey',

--- a/man/plot_confidence_intervals.Rd
+++ b/man/plot_confidence_intervals.Rd
@@ -66,8 +66,10 @@ default color scale is used. Ignored if \code{color_col} is \code{NULL}.}
 between rows when \code{group_col} is supplied. Default \code{TRUE}.}
 
 \item{shape_col}{Optional string name of a column to use for point shapes.
-When \code{NULL} (default), no shape encoding is applied. Must be a factor or
-character column. Can be used independently or in combination with \code{color_col}.}
+When \code{NULL} (default), no shape encoding is applied. Can be a factor or
+character column; character columns are coerced to factor with sorted level
+ordering for stable shape assignment. Can be used independently or in
+combination with \code{color_col}.}
 
 \item{sep_linetype}{Line type for row separator lines. Default \code{"solid"}.}
 

--- a/man/plot_confidence_intervals.Rd
+++ b/man/plot_confidence_intervals.Rd
@@ -14,7 +14,8 @@ plot_confidence_intervals(
   dodge_width = 0.3,
   color_col = NULL,
   color_values = NULL,
-  style = c("color", "shape"),
+  show_separators = TRUE,
+  shape_col = NULL,
   sep_linetype = "solid",
   sep_linewidth = 0.4,
   sep_color = "black",
@@ -61,16 +62,18 @@ values should be valid R color names or hex codes (e.g.,
 \code{c(g1 = "#FF0000", g2 = "#0000FF")}). If \code{NULL} (default), ggplot2's
 default color scale is used. Ignored if \code{color_col} is \code{NULL}.}
 
-\item{style}{String. Controls group encoding when \code{group_col} is supplied.
-\code{"color"} (default) uses different colors per group and draws horizontal
-separator lines between rows. \code{"shape"} uses the same color per
-\code{id} row and different point shapes per group.}
+\item{show_separators}{Logical. Whether to draw horizontal separator lines
+between rows when \code{group_col} is supplied. Default \code{TRUE}.}
 
-\item{sep_linetype}{Line type for row separator lines when \code{style = "color"}. Default \code{"solid"}.}
+\item{shape_col}{Optional string name of a column to use for point shapes.
+When \code{NULL} (default), no shape encoding is applied. Must be a factor or
+character column. Can be used independently or in combination with \code{color_col}.}
 
-\item{sep_linewidth}{Line width for row separator lines when \code{style = "color"}. Default \code{0.4}.}
+\item{sep_linetype}{Line type for row separator lines. Default \code{"solid"}.}
 
-\item{sep_color}{Color for row separator lines when \code{style = "color"}. Default \code{"black"}.}
+\item{sep_linewidth}{Line width for row separator lines. Default \code{0.4}.}
+
+\item{sep_color}{Color for row separator lines. Default \code{"black"}.}
 
 \item{vline_xintercept}{Numeric. Position of the vertical reference line. Default \code{0}.}
 
@@ -79,8 +82,8 @@ separator lines between rows. \code{"shape"} uses the same color per
 \item{vline_color}{Color for the vertical reference line. Default \code{"black"}.}
 
 \item{point_shapes}{Integer vector of point shapes to use when
-\code{style = "shape"}. Must have at least as many elements as there are
-levels in \code{group_col}. Defaults to \code{c(21, 24, 22, 25, 23)} (up to 5
+\code{shape_col} is specified. Must have at least as many elements as there are
+levels in \code{shape_col}. Defaults to \code{c(21, 24, 22, 25, 23)} (up to 5
 groups). See \code{\link[graphics:points]{graphics::points()}} for shape codes.}
 
 \item{pvalue_col}{Optional string name of a column in \code{data} containing
@@ -154,7 +157,8 @@ plot_confidence_intervals(
   ci_high = "conf.high",
   id = "cell_line",
   group_col = "group",
-  style = "shape"
+  shape_col = "group",
+  show_separators = FALSE
 )
 
 # With grouping: color by group with custom colors
@@ -169,7 +173,7 @@ plot_confidence_intervals(
   color_values = c(g1 = "#E69F00", g2 = "#56B4E9")
 )
 
-# Color by label instead of group
+# Color by label, shapes by group
 plot_confidence_intervals(
   df,
   effect_size = "est",
@@ -177,7 +181,7 @@ plot_confidence_intervals(
   ci_high = "conf.high",
   id = "cell_line",
   group_col = "group",
-  style = "shape",
+  shape_col = "group",
   color_col = "cell_line"
 )
 

--- a/man/plot_pvalue_barplot.Rd
+++ b/man/plot_pvalue_barplot.Rd
@@ -19,7 +19,7 @@ plot_pvalue_barplot(
   vline_color = "red",
   vline_legend = TRUE,
   show_y_labels = FALSE,
-  mlog10_transform_pvalue = FALSE,
+  mlog10_transform_pvalue = TRUE,
   also_show_qvalue = TRUE,
   custom_qvalues = NULL,
   color_qvalue = "grey",

--- a/tests/testthat/test-plot_confidence_intervals.R
+++ b/tests/testthat/test-plot_confidence_intervals.R
@@ -136,7 +136,8 @@ test_that("plot_confidence_intervals works with shape style", {
         ci_high = "conf.high",
         id = "cell_line",
         group_col = "group",
-        style = "shape"
+        shape_col = "group",
+        show_separators = FALSE
     )
     expect_s3_class(p, "ggplot")
 })
@@ -157,7 +158,7 @@ test_that("plot_confidence_intervals works with shape style and color", {
         ci_high = "conf.high",
         id = "cell_line",
         group_col = "group",
-        style = "shape",
+        shape_col = "group",
         color_col = "group"
     )
     expect_s3_class(p, "ggplot")
@@ -180,7 +181,7 @@ test_that("plot_confidence_intervals requires point_shapes length matches group 
             ci_high = "conf.high",
             id = "cell_line",
             group_col = "group",
-            style = "shape",
+            shape_col = "group",
             point_shapes = c(21)
         ),
         "point_shapes has 1 element"
@@ -263,7 +264,8 @@ test_that("plot_confidence_intervals works with separator line customization", {
         ci_high = "conf.high",
         id = "cell_line",
         group_col = "group",
-        style = "color",
+        color_col = "group",
+        show_separators = TRUE,
         sep_linetype = "dashed",
         sep_linewidth = 0.8,
         sep_color = "gray50"
@@ -620,7 +622,7 @@ test_that("plot_confidence_intervals works with color_values and shape style", {
         ci_high = "conf.high",
         id = "cell_line",
         group_col = "group",
-        style = "shape",
+        shape_col = "group",
         color_col = "group",
         color_values = c(g1 = "#FF0000", g2 = "#0000FF")
     )

--- a/tests/testthat/test-plot_confidence_intervals.R
+++ b/tests/testthat/test-plot_confidence_intervals.R
@@ -651,3 +651,70 @@ test_that("plot_confidence_intervals validates color_values is named vector", {
         "color_values must be NULL or a named character vector"
     )
 })
+
+test_that("plot_confidence_intervals works with shape_col as character column", {
+    df <- data.frame(
+        cell_line = factor(c("A", "A", "B", "B"), levels = c("A", "B")),
+        est = c(0.2, 0.35, -0.1, 0.05),
+        conf.low = c(0.0, 0.10, -0.3, -0.10),
+        conf.high = c(0.4, 0.60, 0.1, 0.20),
+        group = c("g1", "g2", "g1", "g2") # character, not factor
+    )
+
+    p <- plot_confidence_intervals(
+        df,
+        effect_size = "est",
+        ci_low = "conf.low",
+        ci_high = "conf.high",
+        id = "cell_line",
+        shape_col = "group",
+        point_shapes = c(21, 24)
+    )
+    expect_s3_class(p, "ggplot")
+})
+
+test_that("plot_confidence_intervals validates point_shapes length with character shape_col", {
+    df <- data.frame(
+        cell_line = factor(c("A", "A", "B", "B"), levels = c("A", "B")),
+        est = c(0.2, 0.35, -0.1, 0.05),
+        conf.low = c(0.0, 0.10, -0.3, -0.10),
+        conf.high = c(0.4, 0.60, 0.1, 0.20),
+        group = c("g1", "g2", "g1", "g2") # character, not factor
+    )
+
+    expect_error(
+        plot_confidence_intervals(
+            df,
+            effect_size = "est",
+            ci_low = "conf.low",
+            ci_high = "conf.high",
+            id = "cell_line",
+            shape_col = "group",
+            point_shapes = c(21) # only 1 shape but group has 2 unique values
+        ),
+        "point_shapes has 1 element"
+    )
+})
+
+test_that("plot_confidence_intervals works with shape_col as character and color_col", {
+    df <- data.frame(
+        cell_line = factor(c("A", "A", "B", "B"), levels = c("A", "B")),
+        est = c(0.2, 0.35, -0.1, 0.05),
+        conf.low = c(0.0, 0.10, -0.3, -0.10),
+        conf.high = c(0.4, 0.60, 0.1, 0.20),
+        group = c("g1", "g2", "g1", "g2"), # character, not factor
+        color_group = factor(c("c1", "c2", "c1", "c2"), levels = c("c1", "c2"))
+    )
+
+    p <- plot_confidence_intervals(
+        df,
+        effect_size = "est",
+        ci_low = "conf.low",
+        ci_high = "conf.high",
+        id = "cell_line",
+        shape_col = "group",
+        color_col = "color_group",
+        point_shapes = c(21, 24)
+    )
+    expect_s3_class(p, "ggplot")
+})


### PR DESCRIPTION
…ndent `shape_col` and `show_separators` options; default `mlog10_transform_pvalue` to TRUE in plot_pvalue_barplot